### PR TITLE
Allow `-` in Procfile names

### DIFF
--- a/start/procfile.go
+++ b/start/procfile.go
@@ -17,7 +17,7 @@ type procfileEntry struct {
 type procfile []procfileEntry
 
 func parseProcfile(procfile string, portBase, portStep int) (pf procfile) {
-	re, _ := regexp.Compile("^(\\w+):\\s+(.+)$")
+	re, _ := regexp.Compile("^([\\w-]+):\\s+(.+)$")
 
 	f, err := os.Open(procfile)
 	utils.FatalOnErr(err)


### PR DESCRIPTION
This should allow names in Procfiles to have `-` in their names, like `foreman` does, e.g.:

```rb
hot-assets: …
dev-grunt: …
nvm-install: …
```

I am sorry, I haven't been able to build `overmind` locally to test it out.