### PR TITLE
Add ability to kill a single process

### DIFF
--- a/cmd_kill.go
+++ b/cmd_kill.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/DarthSim/overmind/utils"
 

--- a/cmd_kill.go
+++ b/cmd_kill.go
@@ -13,11 +13,11 @@ type cmdKillHandler struct {
 	SocketPath string
 }
 
-func (c *cmdKillHandler) Run(_ *cli.Context) error {
-	conn, err := net.Dial("unix", c.SocketPath)
+func (k *cmdKillHandler) Run(c *cli.Context) error {
+	conn, err := net.Dial("unix", k.SocketPath)
 	utils.FatalOnErr(err)
 
-	fmt.Fprintf(conn, "kill")
+	fmt.Fprintf(conn, "kill %v\n", strings.Join(c.Args(), " "))
 
 	return nil
 }

--- a/launch/command.go
+++ b/launch/command.go
@@ -76,6 +76,10 @@ func (c *command) Stop() {
 	c.proc.Stop()
 }
 
+func (c *command) KillOne() {
+	c.proc.KillOne()
+}
+
 func (c *command) Restart() {
 	c.restart = true
 	c.Stop()

--- a/launch/command_center.go
+++ b/launch/command_center.go
@@ -25,6 +25,8 @@ func (c *commandCenter) Start() {
 		}
 
 		switch string(b) {
+		case "kill":
+			c.command.KillOne()
 		case "stop":
 			c.command.Stop()
 		case "restart":

--- a/launch/process.go
+++ b/launch/process.go
@@ -100,6 +100,22 @@ func (p *process) Stop() {
 	}
 }
 
+func (p *process) KillOne() {
+	if !p.Running() {
+		return
+	}
+
+	if p.interrupted {
+		// Ok, we tried this easy way, it's time to kill
+		p.writer.WriteBoldLine("Killing...")
+		p.signal(syscall.SIGKILL)
+	} else {
+		p.writer.WriteBoldLine("Interrupting...")
+		p.signal(syscall.SIGINT)
+		p.interrupted = true
+	}
+}
+
 func (p *process) signal(sig os.Signal) {
 	if !p.Running() {
 		return

--- a/start/command_center.go
+++ b/start/command_center.go
@@ -85,7 +85,7 @@ func (c *commandCenter) handleConnection(conn net.Conn) {
 		case "restart":
 			c.processRestart(cmd, args)
 		case "kill":
-			c.processKill()
+			c.processKill(cmd, args)
 		case "get-connection":
 			c.processGetConnection(cmd, args, conn)
 		}
@@ -110,9 +110,17 @@ func (c *commandCenter) processRestart(cmd string, args []string) {
 	}
 }
 
-func (c *commandCenter) processKill() {
-	for _, p := range c.processes {
-		p.Kill()
+func (c *commandCenter) processKill(cmd string, args []string) {
+	if len(args) > 0 {
+		for _, n := range args {
+			if p, ok := c.processes[n]; ok {
+				p.KillOne()
+			}
+		}
+	} else {
+		for _, p := range c.processes {
+			p.Kill()
+		}
 	}
 }
 

--- a/start/process.go
+++ b/start/process.go
@@ -126,6 +126,12 @@ func (p *process) Kill() {
 	}
 }
 
+func (p *process) KillOne() {
+	if p.Running() && p.conn != nil {
+		p.conn.KillOne()
+	}
+}
+
 func (p *process) Restart() {
 	if p.conn != nil {
 		p.conn.Restart()

--- a/start/process_connection.go
+++ b/start/process_connection.go
@@ -14,6 +14,10 @@ func (c *processConnection) Reader() io.Reader {
 	return io.Reader(c.conn)
 }
 
+func (c *processConnection) KillOne() {
+	fmt.Fprintln(c.conn, "kill")
+}
+
 func (c *processConnection) Stop() {
 	fmt.Fprintln(c.conn, "stop")
 }


### PR DESCRIPTION
#### Use Case
I need to reset my database. I can't reset my database without taking down a few of the services momentarily. The only way I know (could be wrong) is to `overmind kill` and start back up
___ 
Users can now send a list of commands to kill (similar to restart)

1. `overmind kill web other_web_thing`
2. (reset your db, whathaveyou)
3. `overmind restart web other_web_thing`