### PR TITLE
print a message if overmind is running when starting as a daemon

### DIFF
--- a/start/command.go
+++ b/start/command.go
@@ -121,6 +121,10 @@ func (c *command) Run() (int, error) {
 	c.output.WriteBoldLinef(nil, "Listening at %v", c.cmdCenter.SocketPath)
 
 	if c.daemonize {
+    if socketFileExists(c.cmdCenter.SocketPath) {
+      c.output.WriteBoldLinef(nil, "It looks like Overmind is already running. If it's not, remove %s and try again", c.cmdCenter.SocketPath)
+      return 0, nil
+    }
 		ctx := new(daemon.Context)
 		child, err := ctx.Reborn()
 
@@ -213,3 +217,11 @@ func (c *command) waitForTimeoutOrStop() {
 	case <-c.stopTrig:
 	}
 }
+
+func socketFileExists(filename string) bool {
+    info, err := os.Stat(filename)
+    if os.IsNotExist(err) {
+        return false
+    }
+    return !info.IsDir()
+  }

--- a/start/command_center.go
+++ b/start/command_center.go
@@ -30,7 +30,7 @@ func newCommandCenter(cmd *command, socket string) (*commandCenter, error) {
 func (c *commandCenter) Start() (err error) {
 	if c.listener, err = net.Listen("unix", c.SocketPath); err != nil {
 		if strings.Contains(err.Error(), "address already in use") {
-			err = fmt.Errorf("it looks like Overmind is already running. If it's not, remove %s and try again", c.SocketPath)
+			err = fmt.Errorf("It looks like Overmind is already running. If it's not, remove %s and try again", c.SocketPath)
 		}
 		return
 	}


### PR DESCRIPTION
Thanks for putting out overmind, great tool. I use it daily and have been running it as a daemon sometimes. 

I noticed that if starts attached to a terminal you get a message that overmind is already running elsewhere, but if you run it as a daemon you don't get that feedback and it falsely looks like it succeeds in starting the process as a daemon. 

This PR adds a check to see if the UNIX socket is open and if so prints the same message as when you try to start it attached to a terminal. 