### PR TITLE
Prevent cutting line when reading from procfile.

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -92,7 +92,7 @@ func ScanLines(r io.Reader, callback func([]byte) bool) error {
 	reader := bufio.NewReader(r)
 
 	for {
-		line, _, err = reader.ReadLine()
+		line, _, err = reader.ReadBytes('\n')
 		if err != nil {
 			break
 		}


### PR DESCRIPTION
Hello! 

Thanks for making a great library- we very much enjoy it at NoRedInk! However, I ran into some trouble when my procfile had very long lines. I believe this fixes it, but of course, you will be the final judge of that. I realize sometime things are more complicated than they look!

Explanation for the fix:
ReadLine() cuts off line when it gets too long for the buffer. ReadBytes('\n') does not. Read more here: https://golang.org/pkg/bufio/#Reader.ReadLine

Thanks for reading!