### PR TITLE
Handle last line process output without new line end

### DIFF
--- a/start/tmux.go
+++ b/start/tmux.go
@@ -153,7 +153,13 @@ func (t *tmuxClient) listen() {
 		case "output":
 			output := outputRe.FindStringSubmatch(tmuxOut[2])
 			if len(output) > 2 {
-				t.sendOutput(output[1], output[2])
+				text := output[2]
+				// the last line of the process output may not contain new line char
+				// but here we write to the pipe that consumed line by line
+				if !strings.HasSuffix(text, "\n") {
+					text = fmt.Sprintf("%s\r\n", text)
+				}
+				t.sendOutput(output[1], text)
 			}
 		}
 	}


### PR DESCRIPTION
Consider process like `echo -n "text"`, it prints "text" without
new line at the end and exit. Current overmind's output writer read
from processes output pipe line by line and in this case
it won't process "text" before overmind exit.
Therefore we must ensure that lines passed to the output writer
are always end with new line char. Fixes #81 