### PR TITLE
Consider SIGHUP as termination signal. fixes #50

### DIFF
--- a/start/command.go
+++ b/start/command.go
@@ -173,7 +173,7 @@ func (c *command) runProcesses() {
 }
 
 func (c *command) waitForExit() {
-	signal.Notify(c.stopTrig, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(c.stopTrig, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
 	c.waitForDoneOrStop()
 


### PR DESCRIPTION
When user close terminal or tmux pane it sends
SIGHUP to current process. When overmind receive SIGHUP
it just terminate and leaves .overmind.sock and tmux running.
There is no way for user to recover from that state except
to kill left processes and clean sock file by hands.