### PR TITLE
Support nested procfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,20 @@ $ overmind restart -s path/to/socket sidekiq
 $ overmind kill -s path/to/socket
 ```
 
+### Nested Procfile
+
+Overmind supports an extension to the Procfile syntax to reuse other Procfiles
+in your project.
+
+```Procfile
+assets: gulp watch
+-f backend/Procfile
+-f frontend/Procfile
+```
+
+A use case for this would be monorepos where multiple Procfiles are defined in
+sub-directories across the project.
+
 ## Known issues
 
 ### Overmind uses system Ruby/Node/etc instead of custom-defined one

--- a/start/command.go
+++ b/start/command.go
@@ -80,6 +80,7 @@ func newCommand(h *Handler) (*command, error) {
 				e.Name,
 				colors[i%len(colors)],
 				e.Command,
+				filepath.Dir(e.Procfile),
 				e.Port,
 				c.output,
 				utils.StringsContain(canDie, e.OrigName),

--- a/start/command.go
+++ b/start/command.go
@@ -74,13 +74,17 @@ func newCommand(h *Handler) (*command, error) {
 	autoRestart := utils.SplitAndTrim(h.AutoRestart)
 
 	for i, e := range procs {
+		dir, err := filepath.Abs(filepath.Dir(e.Procfile))
+		if err != nil {
+			utils.FatalOnErr(err)
+		}
 		if len(procNames) == 0 || utils.StringsContain(procNames, e.OrigName) {
 			c.processes[e.Name] = newProcess(
 				c.tmux,
 				e.Name,
 				colors[i%len(colors)],
 				e.Command,
-				filepath.Dir(e.Procfile),
+				dir,
 				e.Port,
 				c.output,
 				utils.StringsContain(canDie, e.OrigName),

--- a/start/process.go
+++ b/start/process.go
@@ -34,12 +34,12 @@ type process struct {
 	Name    string
 	Color   int
 	Command string
-	Directory string
+	Dir     string
 }
 
 type processesMap map[string]*process
 
-func newProcess(tmux *tmuxClient, name string, color int, command, directory string, port int, output *multiOutput, canDie bool, autoRestart bool, stopSignal syscall.Signal) *process {
+func newProcess(tmux *tmuxClient, name string, color int, command, dir string, port int, output *multiOutput, canDie bool, autoRestart bool, stopSignal syscall.Signal) *process {
 	out, in := io.Pipe()
 
 	proc := &process{
@@ -57,7 +57,7 @@ func newProcess(tmux *tmuxClient, name string, color int, command, directory str
 		Name:    name,
 		Color:   color,
 		Command: fmt.Sprintf("export PORT=%d; %s", port, command),
-		Directory:   directory,
+		Dir:     dir,
 	}
 
 	tmux.AddProcess(proc)

--- a/start/process.go
+++ b/start/process.go
@@ -34,11 +34,12 @@ type process struct {
 	Name    string
 	Color   int
 	Command string
+	Directory string
 }
 
 type processesMap map[string]*process
 
-func newProcess(tmux *tmuxClient, name string, color int, command string, port int, output *multiOutput, canDie bool, autoRestart bool, stopSignal syscall.Signal) *process {
+func newProcess(tmux *tmuxClient, name string, color int, command, directory string, port int, output *multiOutput, canDie bool, autoRestart bool, stopSignal syscall.Signal) *process {
 	out, in := io.Pipe()
 
 	proc := &process{
@@ -56,6 +57,7 @@ func newProcess(tmux *tmuxClient, name string, color int, command string, port i
 		Name:    name,
 		Color:   color,
 		Command: fmt.Sprintf("export PORT=%d; %s", port, command),
+		Directory:   directory,
 	}
 
 	tmux.AddProcess(proc)

--- a/start/procfile.go
+++ b/start/procfile.go
@@ -44,7 +44,7 @@ func resolveProcs(h *Handler) (ps procs) {
 		}
 
 		if len(shortPath) > 1 {
-			iname = fmt.Sprintf("%s:%s", shortPath, iname)
+			iname = fmt.Sprintf("%s/%s", shortPath, iname)
 		}
 
 		num := 1

--- a/start/procfile.go
+++ b/start/procfile.go
@@ -33,11 +33,11 @@ func resolveProcs(h *Handler) (ps procs) {
 	root, _ := h.AbsRoot()
 	names := make(map[string]bool)
 
-	pf := parseProcfile(h.Procfile, root)
+	pf := parseProcfile(filepath.Clean(h.Procfile), root)
 	for i, p := range pf {
 		num := 1
 		name := p.Name
-		iname := fmt.Sprintf("%s#%s", name, p.Procfile)
+		iname := fmt.Sprintf("%s:%s", name, p.Procfile)
 
 		if fnum, ok := h.Formation[name]; ok {
 			num = fnum

--- a/start/procfile.go
+++ b/start/procfile.go
@@ -100,16 +100,7 @@ func parseProcfile(procfile string, absDir string) (pf procfile) {
 			nextPFPath := filepath.Join(filepath.Dir(procfile), nextProcfile)
 
 			npf := parseProcfile(nextPFPath, absDir)
-			for _, p := range npf {
-				pf = append(
-					pf,
-					procfileEntry{
-						Name:       p.Name,
-						Command:    p.Command,
-						Procfile:   p.Procfile,
-					},
-				)
-			}
+			pf = append(pf, npf...)
 		}
 
 		pparams := reProc.FindStringSubmatch(string(b))

--- a/start/procfile.go
+++ b/start/procfile.go
@@ -35,10 +35,19 @@ func resolveProcs(h *Handler) (ps procs) {
 
 	pf := parseProcfile(filepath.Clean(h.Procfile), root)
 	for i, p := range pf {
-		num := 1
 		name := p.Name
-		iname := fmt.Sprintf("%s:%s", name, p.Procfile)
+		iname := name
 
+		shortPath := p.Procfile
+		if filepath.Base(p.Procfile) == "Procfile" {
+			shortPath = filepath.Dir(p.Procfile)
+		}
+
+		if len(shortPath) > 1 {
+			iname = fmt.Sprintf("%s:%s", iname, shortPath)
+		}
+
+		num := 1
 		if fnum, ok := h.Formation[name]; ok {
 			num = fnum
 		} else if fnum, ok := h.Formation["all"]; ok {
@@ -46,7 +55,7 @@ func resolveProcs(h *Handler) (ps procs) {
 		}
 
 		if num > 1 {
-			iname = fmt.Sprintf("%s#%d", name, i+1)
+			iname = fmt.Sprintf("%s#%d", iname, i+1)
 		}
 
 		if names[iname] {

--- a/start/procfile.go
+++ b/start/procfile.go
@@ -44,7 +44,7 @@ func resolveProcs(h *Handler) (ps procs) {
 		}
 
 		if len(shortPath) > 1 {
-			iname = fmt.Sprintf("%s:%s", iname, shortPath)
+			iname = fmt.Sprintf("%s:%s", shortPath, iname)
 		}
 
 		num := 1

--- a/start/procfile.go
+++ b/start/procfile.go
@@ -3,6 +3,7 @@ package start
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"syscall"
 
@@ -10,73 +11,119 @@ import (
 )
 
 type procfileEntry struct {
+	Name     string
+	Command  string
+	Procfile string
+}
+
+type procEntry struct {
 	Name       string
 	OrigName   string
 	Command    string
 	Port       int
+	Procfile   string
 	StopSignal syscall.Signal
 }
 
 type procfile []procfileEntry
+type procs []procEntry
 
-func parseProcfile(procfile string, portBase, portStep int, formation map[string]int, formationPortStep int, stopSignals map[string]syscall.Signal) (pf procfile) {
-	re, _ := regexp.Compile(`^([\w-]+):\s+(.+)$`)
+func resolveProcs(h *Handler) (ps procs) {
+	port := h.PortBase
+	root, _ := h.AbsRoot()
+	names := make(map[string]bool)
+
+	pf := parseProcfile(h.Procfile, root)
+	for i, p := range pf {
+		num := 1
+		name := p.Name
+		iname := fmt.Sprintf("%s#%s", name, p.Procfile)
+
+		if fnum, ok := h.Formation[name]; ok {
+			num = fnum
+		} else if fnum, ok := h.Formation["all"]; ok {
+			num = fnum
+		}
+
+		if num > 1 {
+			iname = fmt.Sprintf("%s#%d", name, i+1)
+		}
+
+		if names[iname] {
+			utils.Fatal("Process names must be uniq")
+		}
+		names[iname] = true
+
+		signal := syscall.SIGINT
+		if s, ok := h.StopSignals[name]; ok {
+			signal = s
+		}
+
+		ps = append(
+			ps,
+			procEntry{
+				Name:       iname,
+				OrigName:   name,
+				Command:    p.Command,
+				Procfile:   p.Procfile,
+				Port:       port + (i * h.FormationPortStep),
+				StopSignal: signal,
+			},
+		)
+		port += h.PortStep
+	}
+	return
+}
+
+// procfile: relative path to the Procfile to be parsed
+// absDir: absolute path from where overmind handler were started
+func parseProcfile(procfile string, absDir string) (pf procfile) {
+	reProc, _ := regexp.Compile(`^([\w-]+):\s+(.+)$`)
+	reFile, _ := regexp.Compile(`^-f\s+(.+)$`)
 
 	f, err := os.Open(procfile)
 	utils.FatalOnErr(err)
-
-	port := portBase
-	names := make(map[string]bool)
 
 	err = utils.ScanLines(f, func(b []byte) bool {
 		if len(b) == 0 {
 			return true
 		}
 
-		params := re.FindStringSubmatch(string(b))
-		if len(params) != 3 {
-			return true
-		}
+		fparams := reFile.FindStringSubmatch(string(b))
+		if len(fparams) == 2 {
+			nextProcfile := fparams[1]
 
-		name, cmd := params[1], params[2]
-
-		num := 1
-		if fnum, ok := formation[name]; ok {
-			num = fnum
-		} else if fnum, ok := formation["all"]; ok {
-			num = fnum
-		}
-
-		signal := syscall.SIGINT
-		if s, ok := stopSignals[name]; ok {
-			signal = s
-		}
-
-		for i := 0; i < num; i++ {
-			iname := name
-
-			if num > 1 {
-				iname = fmt.Sprintf("%s#%d", name, i+1)
+			if filepath.IsAbs(nextProcfile) {
+				utils.Fatal("Nested Procfile must use relative path")
 			}
 
-			if names[iname] {
-				utils.Fatal("Process names must be uniq")
-			}
-			names[iname] = true
+			nextPFPath := filepath.Join(filepath.Dir(procfile), nextProcfile)
 
+			npf := parseProcfile(nextPFPath, absDir)
+			for _, p := range npf {
+				pf = append(
+					pf,
+					procfileEntry{
+						Name:       p.Name,
+						Command:    p.Command,
+						Procfile:   p.Procfile,
+					},
+				)
+			}
+		}
+
+		pparams := reProc.FindStringSubmatch(string(b))
+		if len(pparams) == 3 {
+			name, cmd := pparams[1], pparams[2]
 			pf = append(
 				pf,
 				procfileEntry{
-					Name:       iname,
-					OrigName:   name,
+					Name:       name,
 					Command:    cmd,
-					Port:       port + (i * formationPortStep),
-					StopSignal: signal,
+					Procfile:   procfile,
 				},
 			)
 		}
-
-		port += portStep
 
 		return true
 	})
@@ -84,13 +131,13 @@ func parseProcfile(procfile string, portBase, portStep int, formation map[string
 	utils.FatalOnErr(err)
 
 	if len(pf) == 0 {
-		utils.Fatal("No entries was found in Procfile")
+		utils.Fatal(fmt.Sprintf("No entries was found in '%s'", procfile))
 	}
 
 	return
 }
 
-func (p procfile) MaxNameLength() (nl int) {
+func (p procs) MaxNameLength() (nl int) {
 	for _, e := range p {
 		if l := len(e.Name); nl < l {
 			nl = l

--- a/start/tmux.go
+++ b/start/tmux.go
@@ -95,7 +95,7 @@ func (t *tmuxClient) Start() error {
 		if first {
 			first = false
 
-			args = append(args, "new", "-c", p.Directory, "-n", p.Name, "-s", t.Session, "-P", "-F", tmuxPaneFmt, p.Command, ";")
+			args = append(args, "new", "-c", p.Dir, "-n", p.Name, "-s", t.Session, "-P", "-F", tmuxPaneFmt, p.Command, ";")
 
 			if major, minor := tmuxVersion(); major < 2 || (major == 2 && minor < 6) {
 				if w, h, err := terminal.GetSize(int(os.Stdin.Fd())); err == nil {
@@ -106,7 +106,7 @@ func (t *tmuxClient) Start() error {
 			args = append(args, "setw", "-g", "remain-on-exit", "on", ";")
 			args = append(args, "setw", "-g", "allow-rename", "off", ";")
 		} else {
-			args = append(args, "neww", "-c", p.Directory, "-n", p.Name, "-P", "-F", tmuxPaneFmt, p.Command, ";")
+			args = append(args, "neww", "-c", p.Dir, "-n", p.Name, "-P", "-F", tmuxPaneFmt, p.Command, ";")
 		}
 	}
 

--- a/start/tmux.go
+++ b/start/tmux.go
@@ -95,7 +95,7 @@ func (t *tmuxClient) Start() error {
 		if first {
 			first = false
 
-			args = append(args, "new", "-n", p.Name, "-s", t.Session, "-P", "-F", tmuxPaneFmt, p.Command, ";")
+			args = append(args, "new", "-c", p.Directory, "-n", p.Name, "-s", t.Session, "-P", "-F", tmuxPaneFmt, p.Command, ";")
 
 			if major, minor := tmuxVersion(); major < 2 || (major == 2 && minor < 6) {
 				if w, h, err := terminal.GetSize(int(os.Stdin.Fd())); err == nil {
@@ -106,7 +106,7 @@ func (t *tmuxClient) Start() error {
 			args = append(args, "setw", "-g", "remain-on-exit", "on", ";")
 			args = append(args, "setw", "-g", "allow-rename", "off", ";")
 		} else {
-			args = append(args, "neww", "-n", p.Name, "-P", "-F", tmuxPaneFmt, p.Command, ";")
+			args = append(args, "neww", "-c", p.Directory, "-n", p.Name, "-P", "-F", tmuxPaneFmt, p.Command, ";")
 		}
 	}
 


### PR DESCRIPTION
Implements the following to allow a Procfile to include other Procfiles to 
- Recursively parse `-f <path>` entries in a Procfile
- Add abstraction between a procfile entry and a process entry
- Starts processes from nested Procfiles in the corresponding Procfile's directory using tmux `-c [working-directory]` flag

An example setup in a repo with 1 top-level Procfile and 2 nested Procfiles

```Procfile
# Procfile
-f backend/Procfile
-f frontend/Frocpile
tests: yarn test:watch
```

```Procfile
# backend/Procfile
api: python -m server.http
db: mysql start
```

```Procfile
# frontend/Procfile
web: yarn start
assets: gulp watch
```

To distinguish between processes started from different Procfiles, the relative directory path will be appended to each proc
```
system          | Tmux socket name: overmind-123456
system          | Tmux session ID: om
system          | Listening at ./overmind.sock
backend:api     | Started with pid 52489...
backend:db      | Started with pid 52490...
frontend:web    | Started with pid 52491...
frontend:assets | Started with pid 52492...
tests           | Started with pid 52499...
```

A few undetermined behaviors with other existing flags that I'd like to hear the maintainer's opinions on:
- Procfile contains nested entries AND `procfile` is not `./Procfile`
- Procfile contains nested entries AND `root` is not directory containing top Procfile