### PR TITLE
Add option for custom tmux socket name

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func setupStartCmd() cli.Command {
 			cli.StringFlag{Name: "stop-signals, i", EnvVar: "OVERMIND_STOP_SIGNALS", Usage: "Specify a signal that will be sent to each process when Overmind will try to stop them. The value passed in should be in the format process=signal,process=signal. Supported signals are: ABRT, INT, KILL, QUIT, STOP, TERM, USR1, USR2"},
 			cli.BoolFlag{Name: "daemonize, D", EnvVar: "OVERMIND_DAEMONIZE", Usage: "Launch Overmind as a daemon. Use 'overmind echo' to view logs and 'overmind quit' to gracefully quit daemonized instance", Destination: &c.Daemonize},
 			cli.StringFlag{Name: "tmux-config, F", EnvVar: "OVERMIND_TMUX_CONFIG", Usage: "Specify an alternative tmux config path to be used by Overmind", Destination: &c.TmuxConfigPath},
+			cli.StringFlag{Name: "tmux-socket-name, L", EnvVar: "OVERMIND_TMUX_SOCKET_NAME", Usage: "Specify a tmux socket name to be used by Overmind", Destination: &c.SocketName},
 			socketFlag(&c.SocketPath),
 		},
 	}

--- a/start/command.go
+++ b/start/command.go
@@ -59,6 +59,9 @@ func newCommand(h *Handler) (*command, error) {
 	}
 
 	instanceID := fmt.Sprintf("overmind-%s-%s", session, nanoid)
+	if len(h.SocketName) > 0 {
+	    instanceID = h.SocketName
+	}
 
 	c.tmux = newTmuxClient(session, instanceID, root, h.TmuxConfigPath)
 	c.output = newMultiOutput(pf.MaxNameLength())

--- a/start/handler.go
+++ b/start/handler.go
@@ -34,6 +34,7 @@ type Handler struct {
 	PortBase, PortStep int
 	ProcNames          string
 	SocketPath         string
+	SocketName         string
 	CanDie             string
 	AutoRestart        string
 	Colors             []int


### PR DESCRIPTION
Audience for this are users who already have a tmux oriented workflow with a tmux server running 24/7. This option allows them to add the `overmind` created session into the same tmux server.