### PR TITLE
Prevent tmux nesting

### DIFF
--- a/cmd_connect.go
+++ b/cmd_connect.go
@@ -27,6 +27,10 @@ func (h *cmdConnectHandler) Run(c *cli.Context) error {
 		utils.Fatal("Specify a single name of process")
 	}
 
+	if f := os.Getenv("TMUX"); len(f) > 0 {
+		utils.Fatal("tmux sessions should be nested with care, unset $TMUX to force")
+	}
+
 	conn, err := net.Dial("unix", h.SocketPath)
 	utils.FatalOnErr(err)
 


### PR DESCRIPTION
This is the same messaging and behaviour of tmux when you try to nest sessions.