### PR TITLE
Allow for specifying processes to not run

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ $ overmind start -l web,sidekiq
 $ OVERMIND_PROCESSES=web,sidekiq overmind start
 ```
 
+#### Not running the specified processes
+
+Similar to the above, if there are some processes in the Procfile that you do not want to run:
+
+```bash
+$ overmind start -x web,sidekiq
+$ OVERMIND_IGNORE_PROCESSES=web,sidekiq overmind start
+```
+
+This takes precedence over the previous `-l` flag. i.e. if you:
+
+```bash
+$ overmind start -l web -x web
+$ OVERMIND_IGNORE_PROCESSES=web OVERMIND_PROCESSES=web overmind start
+```
+
+Nothing will start.
+
 #### Processes that can die
 
 Usually, when a process dies, Overmind will interrupt all other processes. However, you can specify processes that can die without interrupting all other ones:

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func setupStartCmd() cli.Command {
 			cli.StringFlag{Name: "stop-signals, i", EnvVar: "OVERMIND_STOP_SIGNALS", Usage: "Specify a signal that will be sent to each process when Overmind will try to stop them. The value passed in should be in the format process=signal,process=signal. Supported signals are: ABRT, INT, KILL, QUIT, STOP, TERM, USR1, USR2"},
 			cli.BoolFlag{Name: "daemonize, D", EnvVar: "OVERMIND_DAEMONIZE", Usage: "Launch Overmind as a daemon. Use 'overmind echo' to view logs and 'overmind quit' to gracefully quit daemonized instance", Destination: &c.Daemonize},
 			cli.StringFlag{Name: "tmux-config, F", EnvVar: "OVERMIND_TMUX_CONFIG", Usage: "Specify an alternative tmux config path to be used by Overmind", Destination: &c.TmuxConfigPath},
+			cli.StringFlag{Name: "ignored-processes, x", EnvVar: "OVERMIND_IGNORED_PROCESSES", Usage: "Specify process names to prevent from launching. Useful if you want to run all but one or two processes. Divide names with comma. Takes precedence over the 'processes' flag.", Destination: &c.IgnoredProcNames},
 			socketFlag(&c.SocketPath),
 		},
 	}

--- a/start/command.go
+++ b/start/command.go
@@ -64,6 +64,7 @@ func newCommand(h *Handler) (*command, error) {
 	c.output = newMultiOutput(pf.MaxNameLength())
 
 	procNames := utils.SplitAndTrim(h.ProcNames)
+	ignoredProcNames := utils.SplitAndTrim(h.IgnoredProcNames)
 
 	colors := defaultColors
 	if len(h.Colors) > 0 {
@@ -74,7 +75,10 @@ func newCommand(h *Handler) (*command, error) {
 	autoRestart := utils.SplitAndTrim(h.AutoRestart)
 
 	for i, e := range pf {
-		if len(procNames) == 0 || utils.StringsContain(procNames, e.OrigName) {
+		shouldRun := len(procNames) == 0 || utils.StringsContain(procNames, e.OrigName)
+		isIgnored := len(ignoredProcNames) != 0 && utils.StringsContain(ignoredProcNames, e.OrigName)
+
+		if (shouldRun && !isIgnored) {
 			c.processes[e.Name] = newProcess(
 				c.tmux,
 				e.Name,

--- a/start/handler.go
+++ b/start/handler.go
@@ -33,6 +33,7 @@ type Handler struct {
 	Timeout            int
 	PortBase, PortStep int
 	ProcNames          string
+	IgnoredProcNames   string
 	SocketPath         string
 	CanDie             string
 	AutoRestart        string


### PR DESCRIPTION
This is useful in the case where you want to not run one or two process, but keep the rest of the processes running as usual. Inverse of the `OVERMIND_PROCESSES` flag. Takes precedence over that flag.

My particular use case is building a `react-native` app, and needing to run/not run some of the processes per OS. One option is to maintain a list of every process, and add the necessary ones for each OS. The other is to turn off the unused/unwanted processes for each OS. 

This is a more sustainable solution as I won't have to go in and update the master list every time the Procfile changes.

Closes #92 

I have "tested" this by running the newly built binary against another project that uses `overmind`.
