### PR TITLE
Fix typo for OVERMIND_IGNORED_PROCESSES

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,14 @@ Similar to the above, if there are some processes in the Procfile that you do no
 
 ```bash
 $ overmind start -x web,sidekiq
-$ OVERMIND_IGNORE_PROCESSES=web,sidekiq overmind start
+$ OVERMIND_IGNORED_PROCESSES=web,sidekiq overmind start
 ```
 
 This takes precedence over the previous `-l` flag. i.e. if you:
 
 ```bash
 $ overmind start -l web -x web
-$ OVERMIND_IGNORE_PROCESSES=web OVERMIND_PROCESSES=web overmind start
+$ OVERMIND_IGNORED_PROCESSES=web OVERMIND_PROCESSES=web overmind start
 ```
 
 Nothing will start.


### PR DESCRIPTION
Following the README and trying to set the environment variable OVERMIND_IGNORE_PROCESSES does nothing. The reason is that the codebase is looking for OVERMIND_IGNORED_PROCESSES. This is a fix of the typo in the README.