### PR TITLE
Fix loading of home dir env

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"math/rand"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -193,7 +194,8 @@ func main() {
 
 func loadEnvFiles() {
 	// First load the specifically named overmind env files
-	godotenv.Overload("~/.overmind.env")
+	userHomeDir, _ := os.UserHomeDir()
+	godotenv.Overload(path.Join(userHomeDir, ".overmind.env"))
 	godotenv.Overload("./.overmind.env")
 
 	_, skipEnv := os.LookupEnv("OVERMIND_SKIP_ENV")


### PR DESCRIPTION
This attempts to restore the [documented](https://github.com/DarthSim/overmind#overmind-environment) ability to load env vars via ~/.overmind.env. Fixes https://github.com/DarthSim/overmind/issues/98.

I don't see a precedent for testing in the repo (e.g. main_test.go), but basic local testing suggests this does the trick.

Relevant documentation for `os.UserHomeDir`: https://golang.org/pkg/os/#UserHomeDir