### PR TITLE
Add tmux section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,15 @@ You need to pass the same flags to other commands:
 $ overmind connect -s "0.0.0.0:4321" -S "tcp" web
 ```
 
+### Specifying tmux config
+
+Overmind can use a specified tmux config. This is useful if you want to differentiate from your main tmux window, for example adding a custom status line for Overmind or a different prefix key.
+
+```bash
+overmind start -F ~/overmind.tmux.conf
+OVERMIND_TMUX_CONFIG=~/.overmind.tmux.conf overmind start
+```
+
 ## Known issues
 
 ### Overmind uses system Ruby/Node/etc instead of custom-defined one

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ If you need to gain access to process input, you can connect to its `tmux` windo
 $ overmind connect [process_name]
 ```
 
-You can safely disconnect from the window by hitting `Ctrl b` and then `d`.
+You can safely disconnect from the window by hitting `Ctrl b` (or your tmux prefix) and then `d`.
 
 ### Restarting a process
 


### PR DESCRIPTION
It took me an embarrassingly long time to figure out why I couldn't disconnect from Overmind once attached. It was because I was too narrowly focused on the instructions in the README and didn't make the connection that Overmind was reading my own tmux conf which of course seems very obvious now.

In an effort to hopefully save someone else from this pitfall I added a note and section to the README. 

I've since found that I quite like having a separate configuration for Overmind's tmux session because I use it quite differently than I use my main tmux.