### PR TITLE
Apply remain-on-exit tmux option only to windows created by overmind

### DIFF
--- a/start/tmux.go
+++ b/start/tmux.go
@@ -104,11 +104,12 @@ func (t *tmuxClient) Start() error {
 				}
 			}
 
-			args = append(args, "setw", "-g", "remain-on-exit", "on", ";")
 			args = append(args, "setw", "-g", "allow-rename", "off", ";")
 		} else {
 			args = append(args, "neww", "-n", p.Name, "-P", "-F", tmuxPaneMsg, p.Command, ";")
 		}
+
+		args = append(args, "set", "-p", "remain-on-exit", "on", ";")
 	}
 
 	t.cmd = exec.Command("tmux", args...)


### PR DESCRIPTION
Hello :wave: thank you for creating overmind, I really appreciate this tool 🥇
I'm an avid tmux user and I usually run overmind as a daemon. I start my web server and stuff, run `overmind connect` and do all my work right there in that tmux session where I can have everything in one place thanks to overmind 🙂

However, I noticed the `remain-on-exit` tmux option being set globally using `setw -g` and it's making all the windows I open inherit this setting. Looks like it's possible to make `remain-on-exit` only apply to windows that overmind created with this simple change I made. I imagine this would save the trouble of dealing with `Pane is dead` messages for someone looking at some logs with `overmind connect` and quickly wanting to do something in the same tmux session :grin:
The `-p` flag restricts this setting to the pane, so it'll make it possible to even do some work in a split pane in the same windows as process run by overmind.

Thanks again and let me know if you'd be open to this change :blush: