### PR TITLE
Fix README instruction for go installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can download the latest release [here](https://github.com/DarthSim/overmind/
 You need Go 1.17 or later to build the project.
 
 ```bash
-$ go install -u github.com/DarthSim/overmind/v2
+$ go install github.com/DarthSim/overmind/v2@latest
 ```
 
 **Note:** You can update Overmind the same way.


### PR DESCRIPTION
The "Build Overmind from source" was not up to date with the latest go options. The `-u` flag is not available anymore. After a bit of digging I got the install working by using `go install
github.com/DarthSim/overmind/v2@latest`. Thought I'd contribute to avoid this hassle for future newcomers 🙂 