### PR TITLE
Fixed `go install` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can download the latest release [here](https://github.com/DarthSim/overmind/
 You need Go 1.17 or later to build the project.
 
 ```bash
-$ go install -u github.com/DarthSim/overmind/v2
+$ go install github.com/DarthSim/overmind@v2
 ```
 
 **Note:** You can update Overmind the same way.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can download the latest release [here](https://github.com/DarthSim/overmind/
 You need Go 1.17 or later to build the project.
 
 ```bash
-$ go install github.com/DarthSim/overmind@v2
+$ go install github.com/DarthSim/overmind/v2
 ```
 
 **Note:** You can update Overmind the same way.


### PR DESCRIPTION
Hi, the current instruction is failed like:

```
$ go install -u github.com/DarthSim/overmind/v2
flag provided but not defined: -u
usage: go install [build flags] [packages]
Run 'go help install' for details.
```

I fixed it to correct usage of `go install`.