### PR TITLE
Propagate SIGINFO to all processes

### DIFF
--- a/start/process.go
+++ b/start/process.go
@@ -127,6 +127,10 @@ func (p *process) Kill(keepAlive bool) {
 	}
 }
 
+func (p *process) Info() {
+	p.groupSignal(syscall.SIGINFO)
+}
+
 func (p *process) Restart() {
 	p.restart = true
 	p.Stop(false)


### PR DESCRIPTION
My team has been using `overmind` for a while now and 1 thing that's been missing for us has been the propagation of the `SIGINFO` signal. One of our processes traps `SIGINFO`s (through `ctrl + t`) when run in isolation, however when using overmind this no longer works. This change would propagate the `SIGINFO` signal to all overmind processes which would allow for each process to handle the signal itself.

You could test locally this by creating the following `Procfile` at the root of your folder
```Procfile
test: sleep 10000
```
and then running `go build && ./overmind start`. After this press `ctrl + t` to trigger info and verify that you get the output of the `SIGINFO` signal on the `sleep` process. It should look something like
```
load: 8.65  cmd: tmux 59513 waiting 0.00u 0.00s
test   | sleep: about 9998 second(s) left out of the original 10000
```
