### PR TITLE
Allow specifying 'all' for process auto restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ $ overmind start -r rails,webpack
 $ OVERMIND_AUTO_RESTART=rails,webpack overmind start
 ```
 
+The special name `all` can also be used to restart all processes automatically when they die:
+
+```bash
+$ overmind start -r all
+$ OVERMIND_AUTO_RESTART=all overmind start
+```
+
 #### Specifying the colors
 
 Overmind colorizes process names with different colors. It may happen that these colors don't match well with your color scheme. In that case, you can specify your own colors using xterm color codes:

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func setupStartCmd() cli.Command {
 				cli.BoolFlag{Name: "no-port, N", EnvVar: "OVERMIND_NO_PORT", Usage: "Don't set $PORT variable for processes", Destination: &c.NoPort},
 				cli.StringFlag{Name: "can-die, c", EnvVar: "OVERMIND_CAN_DIE", Usage: "Specify names of process which can die without interrupting the other processes. Divide names with comma", Destination: &c.CanDie},
 				cli.BoolFlag{Name: "any-can-die", EnvVar: "OVERMIND_ANY_CAN_DIE", Usage: "No dead processes should stop Overmind. Overrides can-die", Destination: &c.AnyCanDie},
-				cli.StringFlag{Name: "auto-restart, r", EnvVar: "OVERMIND_AUTO_RESTART", Usage: "Specify names of process which will be auto restarted on death. Divide names with comma", Destination: &c.AutoRestart},
+				cli.StringFlag{Name: "auto-restart, r", EnvVar: "OVERMIND_AUTO_RESTART", Usage: "Specify names of process which will be auto restarted on death. Divide names with comma. Use 'all' as a process name to auto restart all processes on death.", Destination: &c.AutoRestart},
 				cli.StringFlag{Name: "colors, b", EnvVar: "OVERMIND_COLORS", Usage: "Specify the xterm color codes that will be used to colorize process names. Divide codes with comma"},
 				cli.BoolFlag{Name: "show-timestamps, T", EnvVar: "OVERMIND_SHOW_TIMESTAMPS", Usage: "Add timestamps to the output", Destination: &c.ShowTimestamps},
 				cli.StringFlag{Name: "formation, m", EnvVar: "OVERMIND_FORMATION", Usage: "Specify the number of each process type to run. The value passed in should be in the format process=num,process=num. Use 'all' as a process name to set value for all processes"},

--- a/start/command.go
+++ b/start/command.go
@@ -94,7 +94,7 @@ func newCommand(h *Handler) (*command, error) {
 				scriptFilePath,
 				c.output,
 				(h.AnyCanDie || utils.StringsContain(canDie, e.OrigName)),
-				utils.StringsContain(autoRestart, e.OrigName),
+				(utils.StringsContain(autoRestart, e.OrigName) || utils.StringsContain(autoRestart, "all")),
 				e.StopSignal,
 			))
 		}


### PR DESCRIPTION
This closes #153 

I ended up going with the suggestion for specifying that all processes should auto restart by passing in `all`, i.e. `overmind start -r all` rather than adding another flag that is specifically for auto restarting all, i.e. `overmind start --auto-restart-all`. I thought this was slightly more intuitive, especially since this is how setting `formation` is already handled.

Let me know what you think!