### PR TITLE
Set `PS` env var for each process

### DIFF
--- a/start/command.go
+++ b/start/command.go
@@ -171,6 +171,7 @@ func (c *command) createScriptFile(e *procfileEntry, shell string, setPort bool)
 	if setPort {
 		fmt.Fprintf(scriptFile, "export PORT=%d\n", e.Port)
 	}
+	fmt.Fprintf(scriptFile, "export OVERMIND_WORKER_NAME=%s\n", e.Name)
 	fmt.Fprintln(scriptFile, e.Command)
 
 	utils.FatalOnErr(scriptFile.Chmod(0744))

--- a/start/command.go
+++ b/start/command.go
@@ -171,7 +171,7 @@ func (c *command) createScriptFile(e *procfileEntry, shell string, setPort bool)
 	if setPort {
 		fmt.Fprintf(scriptFile, "export PORT=%d\n", e.Port)
 	}
-	fmt.Fprintf(scriptFile, "export OVERMIND_WORKER_NAME=%s\n", e.Name)
+	fmt.Fprintf(scriptFile, "export PS=%s\n", e.Name)
 	fmt.Fprintln(scriptFile, e.Command)
 
 	utils.FatalOnErr(scriptFile.Chmod(0744))

--- a/start/tmux.go
+++ b/start/tmux.go
@@ -78,12 +78,11 @@ func (t *tmuxClient) Start() error {
 	first := true
 	for _, p := range t.processes {
 		tmuxPaneMsg := fmt.Sprintf(tmuxPaneMsgFmt, p.Name)
-		commandWithEnv := fmt.Sprintf("OVERMIND_WORKER_NAME=%s %s", p.Name, p.Command)
 
 		if first {
 			first = false
 
-			args = append(args, "new", "-n", p.Name, "-s", t.Session, "-P", "-F", tmuxPaneMsg, commandWithEnv, ";")
+			args = append(args, "new", "-n", p.Name, "-s", t.Session, "-P", "-F", tmuxPaneMsg, p.Command, ";")
 
 			if w, h, err := term.GetSize(int(os.Stdin.Fd())); err == nil {
 				if w > t.outputOffset {
@@ -96,7 +95,7 @@ func (t *tmuxClient) Start() error {
 			args = append(args, "setw", "-g", "remain-on-exit", "on", ";")
 			args = append(args, "setw", "-g", "allow-rename", "off", ";")
 		} else {
-			args = append(args, "neww", "-n", p.Name, "-P", "-F", tmuxPaneMsg, commandWithEnv, ";")
+			args = append(args, "neww", "-n", p.Name, "-P", "-F", tmuxPaneMsg, p.Command, ";")
 		}
 	}
 

--- a/start/tmux.go
+++ b/start/tmux.go
@@ -78,11 +78,12 @@ func (t *tmuxClient) Start() error {
 	first := true
 	for _, p := range t.processes {
 		tmuxPaneMsg := fmt.Sprintf(tmuxPaneMsgFmt, p.Name)
+		commandWithEnv := fmt.Sprintf("OVERMIND_WORKER_NAME=%s %s", p.Name, p.Command)
 
 		if first {
 			first = false
 
-			args = append(args, "new", "-n", p.Name, "-s", t.Session, "-P", "-F", tmuxPaneMsg, p.Command, ";")
+			args = append(args, "new", "-n", p.Name, "-s", t.Session, "-P", "-F", tmuxPaneMsg, commandWithEnv, ";")
 
 			if w, h, err := term.GetSize(int(os.Stdin.Fd())); err == nil {
 				if w > t.outputOffset {
@@ -95,7 +96,7 @@ func (t *tmuxClient) Start() error {
 			args = append(args, "setw", "-g", "remain-on-exit", "on", ";")
 			args = append(args, "setw", "-g", "allow-rename", "off", ";")
 		} else {
-			args = append(args, "neww", "-n", p.Name, "-P", "-F", tmuxPaneMsg, p.Command, ";")
+			args = append(args, "neww", "-n", p.Name, "-P", "-F", tmuxPaneMsg, commandWithEnv, ";")
 		}
 	}
 


### PR DESCRIPTION
This commit:
 - sets an OVERMIND_WORKER_NAME env var populated with the process name for each tmux cmd

Why?
 - It can be useful for each process to be able to reference its 'worker name' as specified in the Procfile.

Closes #148 


There may be a cleaner way to do this than just manipulating the tmux command, I'm certainly open to any suggestions!