### PR TITLE
Add delayed processes as a new argument starting overmind

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func setupStartCmd() cli.Command {
 				cli.BoolFlag{Name: "daemonize, D", EnvVar: "OVERMIND_DAEMONIZE", Usage: "Launch Overmind as a daemon. Use 'overmind echo' to view logs and 'overmind quit' to gracefully quit daemonized instance", Destination: &c.Daemonize},
 				cli.StringFlag{Name: "tmux-config, F", EnvVar: "OVERMIND_TMUX_CONFIG", Usage: "Specify an alternative tmux config path to be used by Overmind", Destination: &c.TmuxConfigPath},
 				cli.StringFlag{Name: "ignored-processes, x", EnvVar: "OVERMIND_IGNORED_PROCESSES", Usage: "Specify process names to prevent from launching. Useful if you want to run all but one or two processes. Divide names with comma. Takes precedence over the 'processes' flag.", Destination: &c.IgnoredProcNames},
+				cli.StringFlag{Name: "delayed-processes, X", EnvVar: "OVERMIND_DELAYED_PROCESSES", Usage: "Specify process names to prevent from launching right now. Useful if you want to run one or two processes later. Divide names with comma. Takes precedence over the 'processes' flag.", Destination: &c.DelayedProcNames},
 				cli.StringFlag{Name: "shell, H", EnvVar: "OVERMIND_SHELL", Usage: "Specify shell to run processes with.", Value: "sh", Destination: &c.Shell},
 			},
 			socketFlags(&c.SocketPath, &c.Network)...,

--- a/start/handler.go
+++ b/start/handler.go
@@ -35,6 +35,7 @@ type Handler struct {
 	PortBase, PortStep int
 	ProcNames          string
 	IgnoredProcNames   string
+	DelayedProcNames   string
 	SocketPath         string
 	Network            string
 	CanDie             string

--- a/start/process.go
+++ b/start/process.go
@@ -19,6 +19,7 @@ type process struct {
 	pid int
 
 	stopSignal   syscall.Signal
+	delayed      bool
 	canDie       bool
 	canDieNow    bool
 	autoRestart  bool
@@ -32,12 +33,13 @@ type process struct {
 	in  io.Writer
 	out io.ReadCloser
 
-	Name    string
-	Color   int
-	Command string
+	Name           string
+	Color          int
+	Command        string
+	DelayedCommand string
 }
 
-func newProcess(tmux *tmuxClient, name string, color int, command string, output *multiOutput, canDie bool, autoRestart bool, stopSignal syscall.Signal) *process {
+func newProcess(tmux *tmuxClient, name string, color int, command string, delayedCommand string, output *multiOutput, delayed bool, canDie bool, autoRestart bool, stopSignal syscall.Signal) *process {
 	out, in := io.Pipe()
 
 	proc := &process{
@@ -45,6 +47,7 @@ func newProcess(tmux *tmuxClient, name string, color int, command string, output
 		tmux:   tmux,
 
 		stopSignal:  stopSignal,
+		delayed:     delayed,
 		canDie:      canDie,
 		canDieNow:   canDie,
 		autoRestart: autoRestart,
@@ -52,9 +55,10 @@ func newProcess(tmux *tmuxClient, name string, color int, command string, output
 		in:  in,
 		out: out,
 
-		Name:    name,
-		Color:   color,
-		Command: command,
+		Name:           name,
+		Color:          color,
+		Command:        command,
+		DelayedCommand: delayedCommand,
 	}
 
 	tmux.AddProcess(proc)

--- a/start/tmux.go
+++ b/start/tmux.go
@@ -79,10 +79,17 @@ func (t *tmuxClient) Start() error {
 	for _, p := range t.processes {
 		tmuxPaneMsg := fmt.Sprintf(tmuxPaneMsgFmt, p.Name)
 
+		var command string
+		if p.delayed {
+			command = p.DelayedCommand
+		} else {
+			command = p.Command
+		}
+
 		if first {
 			first = false
 
-			args = append(args, "new", "-n", p.Name, "-s", t.Session, "-P", "-F", tmuxPaneMsg, p.Command, ";")
+			args = append(args, "new", "-n", p.Name, "-s", t.Session, "-P", "-F", tmuxPaneMsg, command, ";")
 
 			if w, h, err := term.GetSize(int(os.Stdin.Fd())); err == nil {
 				if w > t.outputOffset {
@@ -95,7 +102,7 @@ func (t *tmuxClient) Start() error {
 			args = append(args, "setw", "-g", "remain-on-exit", "on", ";")
 			args = append(args, "setw", "-g", "allow-rename", "off", ";")
 		} else {
-			args = append(args, "neww", "-n", p.Name, "-P", "-F", tmuxPaneMsg, p.Command, ";")
+			args = append(args, "neww", "-n", p.Name, "-P", "-F", tmuxPaneMsg, command, ";")
 		}
 	}
 


### PR DESCRIPTION
Hi. I love your tool and using it for day-to-day development. I've run into only one use case that I wasn't really able to get working, and it's the "not always required" / "delayed" processes.

Let me give you a quick example of what do I mean by that: I have a react native repo where I need to work sometimes. It has a few processes that I would like to start with Overmind, but it also has the emulator that I don't need that often. Currently the only option is to set this emulator to be an ignored process (I don't want it to start every time I'm opening the project), but then `overmind restart emulator` won't recognize the process and won't be able to start it later, so I need to stop all the other processes and restart overmind when I need the emulator.

My change request is trying to solve this scenario: let's just start a noop script for these "delayed" processes than can die immedialety and then you can `overmind restart xy` / `overmind stop xy` whenever you need these processes.

Let me know if this makes sense to you or if I need to make any further changes to have this as a viable feature.