### PR TITLE
2.5.1: correct invoking overmind

### DIFF
--- a/packaging/rubygems/Gemfile.lock
+++ b/packaging/rubygems/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    overmind (0.1.2)
+    overmind (2.5.1)
 
 GEM
   remote: https://rubygems.org/

--- a/packaging/rubygems/bin/overmind
+++ b/packaging/rubygems/bin/overmind
@@ -5,8 +5,7 @@ require 'overmind/cli'
 
 begin
   cli = Overmind::CLI.new
-  exit_code = cli.run(ARGV)
-  exit exit_code
+  cli.run(ARGV)
 rescue StandardError => e
   warn e.message
   exit 1

--- a/packaging/rubygems/lib/overmind/cli.rb
+++ b/packaging/rubygems/lib/overmind/cli.rb
@@ -23,12 +23,8 @@ module Overmind
       # Use prebuild tmux if found
       path_with_tmux = File.exist?(TMUX_PATH) ? "#{TMUX_FOLDER_PATH}:#{ENV["PATH"]}" : ENV["PATH"]
 
-      # Spawns the Overmind process with modified PATH if necessary
-      pid = spawn({"PATH" => path_with_tmux}, "#{OVERMIND_PATH} #{args.join(" ")}")
-
-      Process.wait(pid)
-
-      $?.exitstatus
+      # exec the Overmind process with modified PATH if necessary
+      exec({"PATH" => path_with_tmux}, "#{OVERMIND_PATH} #{args.join(" ")}")
     end
 
     private

--- a/packaging/rubygems/lib/overmind/version.rb
+++ b/packaging/rubygems/lib/overmind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Overmind
-  VERSION = "2.5.0"
+  VERSION = "2.5.1"
 end


### PR DESCRIPTION
Correct invoking overmind library, using `exec` 