### PR TITLE
Clarify the interaction of `OVERMIND_CAN_DIE` and `OVERMIND_AUTO_RESTART`

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ $ overmind start -r all
 $ OVERMIND_AUTO_RESTART=all overmind start
 ```
 
+> [!NOTE] 
+> `OVERMIND_CAN_DIE` supersedes `OVERMIND_AUTO_RESTART`; if you want a restarting process, only put it in `OVERMIND_AUTO_RESTART` 
+
 #### Specifying the colors
 
 Overmind colorizes process names with different colors. It may happen that these colors don't match well with your color scheme. In that case, you can specify your own colors using xterm color codes:


### PR DESCRIPTION
In #190 it was clarified that when you set `OVERMIND_CAN_DIE` then the restart of `OVERMIND_AUTO_RESTART` isn't triggered. 

This PR adds a bit to the README to clarify the interaction.