### PR TITLE
Note about nested tmux sessions in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ You can safely disconnect from the window by hitting `Ctrl b` (or your tmux pref
 
 You can omit the process name to connect to the first process defined in the Procfile.
 
+If you were already in a `tmux` session when you ran `overmind connect` then you will be in a nested `tmux session`.
+To disconnect only from the `overmind` session, use `Ctrl b Ctrl b, d`. Sending `Ctrl b` twice will cause the command
+to be sent to the nested session.
+
 ### Restarting a process
 
 You can restart a single process without restarting all the other ones:

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ You can safely disconnect from the window by hitting `Ctrl b` (or your tmux pref
 
 You can omit the process name to connect to the first process defined in the Procfile.
 
-If you were already in a `tmux` session when you ran `overmind connect` then you will be in a nested `tmux session`.
+If you were already in a `tmux` session when you ran `overmind connect` then you will be in a nested `tmux` session.
 To disconnect only from the `overmind` session, use `Ctrl b Ctrl b, d`. Sending `Ctrl b` twice will cause the command
 to be sent to the nested session.
 


### PR DESCRIPTION
This confused me for a bit, found the post here: https://superuser.com/questions/249659/how-to-detach-a-tmux-session-that-itself-already-in-a-tmux

Figured it would be worth sticking in the readme.